### PR TITLE
Fix filter ID mismatch

### DIFF
--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -108,7 +108,7 @@ const filterGroups: FilterGroup[] = [
     title: 'Foreign Transaction Fee',
     icon: <Globe className="h-5 w-5 text-indigo-600" />,
     options: [
-      { id: 'no-foreign-fee', label: 'No Foreign Transaction Fee' }
+      { id: 'no-foreign-transaction-fee', label: 'No Foreign Transaction Fee' }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- correct the filter ID for no foreign transaction fees

## Testing
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d6891e988323a7e1214e20c91b0e