### PR TITLE
Fix seed script logging

### DIFF
--- a/scripts/seedBooks.js
+++ b/scripts/seedBooks.js
@@ -95,7 +95,7 @@ const books = [
       const data = await res.json();
       console.log('הוזן:', data.title);
     } catch (error) {
-      console.error clocks(`שגיאה בהוספת ${book.title}:`, error);
+      console.error(`שגיאה בהוספת ${book.title}:`, error);
     }
   }
 })();


### PR DESCRIPTION
## Summary
- correct a typo in the database seed script logging

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_687cbc53b01c8323ac92303121ae30da